### PR TITLE
originalTransactionId added for iOS and macOS

### DIFF
--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -65,6 +65,7 @@ export interface Purchase {
   isAcknowledged: boolean;
   originalJson: string;
   signature: string;
+  originalId?: string;
 }
 
 /**

--- a/ios/Sources/IapPlugin.swift
+++ b/ios/Sources/IapPlugin.swift
@@ -406,6 +406,7 @@ class IapPlugin: Plugin {
         
         return [
             "orderId": String(transaction.id),
+            "originalId": String(transaction.originalID),
             "packageName": Bundle.main.bundleIdentifier ?? "",
             "productId": transaction.productID,
             "purchaseTime": Int(transaction.purchaseDate.timeIntervalSince1970 * 1000),

--- a/macos/Sources/IapPlugin.swift
+++ b/macos/Sources/IapPlugin.swift
@@ -367,6 +367,7 @@ private func createPurchaseObject(from transaction: Transaction, product: Produc
     
     return [
         "orderId": String(transaction.id),
+        "originalId": String(transaction.originalID),
         "packageName": Bundle.main.bundleIdentifier ?? "",
         "productId": transaction.productID,
         "purchaseTime": Int(transaction.purchaseDate.timeIntervalSince1970 * 1000),

--- a/src/models.rs
+++ b/src/models.rs
@@ -101,6 +101,7 @@ pub struct Purchase {
     pub is_acknowledged: bool,
     pub original_json: String,
     pub signature: String,
+    pub original_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
When using Apple's in app subscriptions, the originalTransactionId is a fairly important value to track subscription status, I have therefore added it to the Purchase model as well as made sure it is returned for both iOS and macOS.