### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: Checks
 
 on: [ pull_request, push ]
 
+permissions:
+  contents: read
+
 jobs:
   # Code formatting.
   fmt:


### PR DESCRIPTION
Potential fix for [https://github.com/Choochmeque/tauri-plugin-iap/security/code-scanning/12](https://github.com/Choochmeque/tauri-plugin-iap/security/code-scanning/12)

In general, the fix is to explicitly specify `permissions` for the `GITHUB_TOKEN` in the workflow, using the minimum required scopes. Since all the jobs shown (`fmt`, `prettier`, `clippy`, `deadlinks`, `mlc`, `spellcheck`, `deny`, `semver`) only read code and run checks, they can safely share a root‑level `permissions: contents: read` configuration. This both satisfies CodeQL and enforces least privilege.

The best way to fix this without changing existing behavior is to add a single `permissions:` block at the top level of `.github/workflows/checks.yml`, just below the `on:` declaration and before `jobs:`. This will apply to all jobs that don’t override permissions, which matches the existing pattern (none of the jobs currently specify their own permissions). Concretely, between current lines 3 and 5, add:

```yaml
permissions:
  contents: read
```

No other imports, methods, or definitions are needed because this is strictly a YAML configuration change to the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
