### PR TITLE
Android subscription update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Tauri plugin for In-App Purchases (IAP) with support for subscriptions on iOS 
 ## Platform Support
 
 - **iOS**: StoreKit 2 (requires iOS 15.0+)
-- **Android**: Google Play Billing Library v8.0.0
+- **Android**: Google Play Billing Library v9.0.0
 - **Windows**: Microsoft Store API (Windows 10/11)
 - **macOS**: StoreKit 2 (requires macOS 13.0+)
 
@@ -150,12 +150,12 @@ const purchaseResult = await purchase('subscription_id_1', 'subs', {
   appAccountToken: '550e8400-e29b-41d4-a716-446655440000'
 });
 
-// Upgrade/downgrade subscription (Android)
+// Upgrade/downgrade subscription (Android, Billing Library 9.0+)
 import { SubscriptionReplacementMode } from '@choochmeque/tauri-plugin-iap-api';
 
 const upgraded = await purchase('premium_subscription', 'subs', {
   offerToken: 'premium_offer_token',
-  oldPurchaseToken: currentSubscription.purchaseToken,
+  oldProductId: currentSubscription.productId,
   subscriptionReplacementMode: SubscriptionReplacementMode.WITH_TIME_PRORATION
 });
 
@@ -310,8 +310,8 @@ Initiates a purchase flow with enhanced options for fraud prevention and account
   - `obfuscatedAccountId`: (Android) Hashed account ID for fraud prevention
   - `obfuscatedProfileId`: (Android) Hashed profile ID for fraud prevention
   - `appAccountToken`: (iOS) UUID string for account tracking and fraud prevention
-  - `oldPurchaseToken`: (Android) Purchase token of existing subscription to replace for upgrades/downgrades
-  - `subscriptionReplacementMode`: (Android) Proration mode using `SubscriptionReplacementMode` enum (defaults to `WITH_TIME_PRORATION`)
+  - `oldProductId`: (Android) Product ID of the existing subscription to replace for upgrades/downgrades (Billing Library 9.0+)
+  - `subscriptionReplacementMode`: (Android) Proration mode using `SubscriptionReplacementMode` enum — `WITH_TIME_PRORATION`, `CHARGE_PRORATED_PRICE`, `WITHOUT_PRORATION`, `CHARGE_FULL_PRICE`, `DEFERRED`, `KEEP_EXISTING` (defaults to `WITH_TIME_PRORATION`)
 
 **Returns:** Purchase object with transaction details
 

--- a/android/src/main/java/app/tauri/iap/IapPlugin.kt
+++ b/android/src/main/java/app/tauri/iap/IapPlugin.kt
@@ -29,7 +29,7 @@ class PurchaseArgs {
     var offerToken: String? = null
     var obfuscatedAccountId: String? = null
     var obfuscatedProfileId: String? = null
-    var oldPurchaseToken: String? = null
+    var oldProductId: String? = null
     var subscriptionReplacementMode: Int? = null
 }
 
@@ -207,42 +207,42 @@ class IapPlugin(private val activity: Activity): Plugin(activity), PurchasesUpda
             if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && productDetailsResult.productDetailsList.isNotEmpty()) {
                 val productDetails = productDetailsResult.productDetailsList[0]
 
-                // Get offer token from args or from first available subscription offer
-                val offerToken = args.offerToken ?: 
-                    productDetails.subscriptionOfferDetails?.firstOrNull()?.offerToken
-                
                 val productDetailsParamsBuilder = BillingFlowParams.ProductDetailsParams.newBuilder()
                     .setProductDetails(productDetails)
-                
-                offerToken?.let { productDetailsParamsBuilder.setOfferToken(it) }
-                
-                val productDetailsParamsList = listOf(productDetailsParamsBuilder.build())
-                
-                val billingFlowParamsBuilder = BillingFlowParams.newBuilder()
-                    .setProductDetailsParamsList(productDetailsParamsList)
-                
-                // Add obfuscated account ID if provided
-                args.obfuscatedAccountId?.let { accountId ->
-                    billingFlowParamsBuilder.setObfuscatedAccountId(accountId)
-                }
-                
-                // Add obfuscated profile ID if provided
-                args.obfuscatedProfileId?.let { profileId ->
-                    billingFlowParamsBuilder.setObfuscatedProfileId(profileId)
+
+                // Subscription upgrade/downgrade: attach replacement params per-product (Billing 9.0+)
+                val isKeepExisting = args.oldProductId != null &&
+                    args.subscriptionReplacementMode == BillingFlowParams.ProductDetailsParams
+                        .SubscriptionProductReplacementParams.ReplacementMode.KEEP_EXISTING
+
+                // KEEP_EXISTING must not set an offer token (Play rejects the flow otherwise).
+                if (!isKeepExisting) {
+                    val offerToken = args.offerToken
+                        ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.offerToken
+                    offerToken?.let { productDetailsParamsBuilder.setOfferToken(it) }
                 }
 
-                // Add subscription update params for upgrades/downgrades
-                args.oldPurchaseToken?.let { oldToken ->
+                args.oldProductId?.let { oldId ->
                     val replacementMode = args.subscriptionReplacementMode
-                        ?: BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.WITH_TIME_PRORATION
+                        ?: BillingFlowParams.ProductDetailsParams
+                            .SubscriptionProductReplacementParams.ReplacementMode.WITH_TIME_PRORATION
 
-                    val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder()
-                        .setOldPurchaseToken(oldToken)
-                        .setSubscriptionReplacementMode(replacementMode)
+                    val replacementParams = BillingFlowParams.ProductDetailsParams
+                        .SubscriptionProductReplacementParams.newBuilder()
+                        .setOldProductId(oldId)
+                        .setReplacementMode(replacementMode)
                         .build()
 
-                    billingFlowParamsBuilder.setSubscriptionUpdateParams(subscriptionUpdateParams)
+                    productDetailsParamsBuilder.setSubscriptionProductReplacementParams(replacementParams)
                 }
+
+                val productDetailsParamsList = listOf(productDetailsParamsBuilder.build())
+
+                val billingFlowParamsBuilder = BillingFlowParams.newBuilder()
+                    .setProductDetailsParamsList(productDetailsParamsList)
+
+                args.obfuscatedAccountId?.let(billingFlowParamsBuilder::setObfuscatedAccountId)
+                args.obfuscatedProfileId?.let(billingFlowParamsBuilder::setObfuscatedProfileId)
 
                 val billingFlowParams = billingFlowParamsBuilder.build()
                 

--- a/examples/iap-demo/package.json
+++ b/examples/iap-demo/package.json
@@ -11,14 +11,14 @@
     "tauri:macos:dev": "tauri-macos-xcode dev --open"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.9.0",
+    "@tauri-apps/api": "^2.11.1",
     "tauri-plugin-iap-api": "file:../../"
   },
   "devDependencies": {
-    "@choochmeque/tauri-macos-xcode": "^0.2.26",
+    "@choochmeque/tauri-macos-xcode": "^0.2.30",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tauri-apps/cli": "^2.11.1",
     "svelte": "^5.56.3",
-    "vite": "^8.0.14"
+    "vite": "^8.0.16"
   }
 }

--- a/examples/iap-demo/pnpm-lock.yaml
+++ b/examples/iap-demo/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       '@tauri-apps/api':
-        specifier: ^2.9.0
-        version: 2.11.0
+        specifier: ^2.11.1
+        version: 2.11.1
       tauri-plugin-iap-api:
         specifier: file:../../
         version: '@choochmeque/tauri-plugin-iap-api@file:../..'
     devDependencies:
       '@choochmeque/tauri-macos-xcode':
-        specifier: ^0.2.26
-        version: 0.2.26
+        specifier: ^0.2.30
+        version: 0.2.30
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.57.0))(vite@8.0.16(esbuild@0.27.2))
@@ -28,13 +28,13 @@ importers:
         specifier: ^5.56.3
         version: 5.56.3(@typescript-eslint/types@8.57.0)
       vite:
-        specifier: ^8.0.14
+        specifier: ^8.0.16
         version: 8.0.16(esbuild@0.27.2)
 
 packages:
 
-  '@choochmeque/tauri-macos-xcode@0.2.26':
-    resolution: {integrity: sha512-XMNHTNZ2dY5P0bCRjdgvavNTvlAN/OhG1F/ZP1UGsoMMJlsqy6gdWAO493Ik2S/MgiXm2IfaYmWEoO876OaFvg==}
+  '@choochmeque/tauri-macos-xcode@0.2.30':
+    resolution: {integrity: sha512-9y9om/E7pargYIR9UKYnHvDxA1Oh+YczB7huyj5stsp2E0jd4ad9JHJSf48CGFVATfa5dmfmQxUiI6f6zDJPiA==}
     hasBin: true
 
   '@choochmeque/tauri-plugin-iap-api@file:../..':
@@ -221,8 +221,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -334,8 +334,8 @@ packages:
       svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
-  '@tauri-apps/api@2.11.0':
-    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
   '@tauri-apps/cli-darwin-arm64@2.11.2':
     resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
@@ -425,8 +425,8 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -844,7 +844,7 @@ packages:
 
 snapshots:
 
-  '@choochmeque/tauri-macos-xcode@0.2.26':
+  '@choochmeque/tauri-macos-xcode@0.2.30':
     dependencies:
       commander: 15.0.0
       image-js: 1.6.1
@@ -856,7 +856,7 @@ snapshots:
 
   '@choochmeque/tauri-plugin-iap-api@file:../..':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.11.1
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -971,7 +971,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -1020,7 +1020,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -1031,9 +1031,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.57.0))(vite@8.0.16(esbuild@0.27.2))':
     dependencies:
@@ -1044,7 +1044,7 @@ snapshots:
       vite: 8.0.16(esbuild@0.27.2)
       vitefu: 1.1.3(vite@8.0.16(esbuild@0.27.2))
 
-  '@tauri-apps/api@2.11.0': {}
+  '@tauri-apps/api@2.11.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.11.2':
     optional: true
@@ -1107,7 +1107,7 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   agent-base@7.1.4:
     optional: true
@@ -1483,10 +1483,10 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -144,19 +144,22 @@ export interface ProductStatus {
 /**
  * Google Play subscription replacement modes for upgrades/downgrades.
  * Used with `subscriptionReplacementMode` in `PurchaseOptions`.
- * @see https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode
+ * Values match the Billing Library 9.0+ `SubscriptionProductReplacementParams.ReplacementMode` constants.
+ * @see https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProductDetailsParams.SubscriptionProductReplacementParams.ReplacementMode
  */
 export enum SubscriptionReplacementMode {
-  /** Replacement takes effect when the old plan expires, and the new price is charged at the same time. */
-  DEFERRED = 6,
   /** Replacement takes effect immediately. The billing cycle remains the same. The remaining value from the old price is prorated for the new plan. */
   WITH_TIME_PRORATION = 1,
-  /** Replacement takes effect immediately. The new price is charged immediately and in full. Any remaining period from the old plan is used to extend the new billing date. */
-  CHARGE_FULL_PRICE = 5,
   /** Replacement takes effect immediately. The new plan price is reduced by the prorated cost of the old plan for the remaining period. */
   CHARGE_PRORATED_PRICE = 2,
   /** Replacement takes effect immediately with no proration. The user is charged full price for the new plan. */
   WITHOUT_PRORATION = 3,
+  /** Replacement takes effect immediately. The new price is charged immediately and in full. Any remaining period from the old plan is used to extend the new billing date. */
+  CHARGE_FULL_PRICE = 4,
+  /** Replacement takes effect when the old plan expires, and the new price is charged at the same time. */
+  DEFERRED = 5,
+  /** Keep the existing plan; do not switch (e.g., to cancel a pending change). Billing Library 9.0+ only. */
+  KEEP_EXISTING = 6,
 }
 
 /**
@@ -172,16 +175,16 @@ export interface PurchaseOptions {
   /** App account token - must be a valid UUID string (iOS only) */
   appAccountToken?: string;
   /**
-   * Purchase token of the existing subscription to replace (Android only).
-   * When set, the purchase becomes a subscription upgrade/downgrade.
-   * Obtain this from a previous purchase's `purchaseToken` field.
+   * Product ID of the existing subscription to replace (Android only).
+   * When set, the purchase becomes a subscription upgrade/downgrade via the
+   * Billing Library 9.0+ `SubscriptionProductReplacementParams` API.
+   * Use the previous purchase's `productId` field.
    */
-  oldPurchaseToken?: string;
+  oldProductId?: string;
   /**
    * Replacement mode for subscription upgrades/downgrades (Android only).
-   * Determines how the transition between old and new subscription is handled.
-   * Use values from the `SubscriptionReplacementMode` enum.
-   * Defaults to `WITH_TIME_PRORATION` if not specified.
+   * Used when `oldProductId` is set. Determines how the transition between
+   * old and new subscription is handled. Defaults to `WITH_TIME_PRORATION`.
    * @see SubscriptionReplacementMode
    */
   subscriptionReplacementMode?: SubscriptionReplacementMode;
@@ -266,7 +269,7 @@ export async function getProducts(
  * // Subscription upgrade/downgrade (Android)
  * const purchase = await purchase('com.example.premium', 'subs', {
  *   offerToken: 'new_plan_offer_token',
- *   oldPurchaseToken: 'existing_subscription_purchase_token',
+ *   oldProductId: 'com.example.basic',
  *   subscriptionReplacementMode: SubscriptionReplacementMode.WITH_TIME_PRORATION
  * });
  * ```

--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
     "format:check": "prettier --check \"./**/*.{cjs,mjs,js,jsx,mts,ts,tsx,html,css,json}\""
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.6.0"
+    "@tauri-apps/api": "^2.11.1"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.4",
-    "@vitest/coverage-v8": "^4.0.13",
-    "@vitest/ui": "^4.0.13",
-    "happy-dom": "^20.0.10",
+    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/ui": "^4.1.9",
+    "happy-dom": "^20.10.5",
     "prettier": "3.8.4",
     "rollup": "^4.60.3",
     "tslib": "^2.6.2",
     "typescript": "^6.0.2",
-    "vitest": "^4.0.13"
+    "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,21 +9,21 @@ importers:
   .:
     dependencies:
       '@tauri-apps/api':
-        specifier: ^2.6.0
-        version: 2.11.0
+        specifier: ^2.11.1
+        version: 2.11.1
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^12.1.4
         version: 12.3.0(rollup@4.62.0)(tslib@2.8.1)(typescript@6.0.3)
       '@vitest/coverage-v8':
-        specifier: ^4.0.13
-        version: 4.1.8(vitest@4.1.8)
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       '@vitest/ui':
-        specifier: ^4.0.13
-        version: 4.1.8(vitest@4.1.8)
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       happy-dom:
-        specifier: ^20.0.10
-        version: 20.10.3
+        specifier: ^20.10.5
+        version: 20.10.5
       prettier:
         specifier: 3.8.4
         version: 3.8.4
@@ -37,26 +37,26 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
       vitest:
-        specifier: ^4.0.13
-        version: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(vite@7.3.1(@types/node@25.6.0))
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.5)(vite@7.3.1(@types/node@25.9.3))
 
 packages:
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -382,8 +382,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tauri-apps/api@2.11.0':
-    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -397,8 +397,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -406,20 +406,20 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@vitest/coverage-v8@4.1.8':
-    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.8
-      vitest: 4.1.8
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -429,32 +429,32 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
-  '@vitest/ui@4.1.8':
-    resolution: {integrity: sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==}
+  '@vitest/ui@4.1.9':
+    resolution: {integrity: sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==}
     peerDependencies:
-      vitest: 4.1.8
+      vitest: 4.1.9
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
@@ -471,8 +471,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -498,8 +498,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -512,8 +512,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  happy-dom@20.10.3:
-    resolution: {integrity: sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==}
+  happy-dom@20.10.5:
+    resolution: {integrity: sha512-0aA6BQoMnpcRE/c1E8ZyF2jXnET7MJskereWOXher4CJuYjrI5esN0Az/1NPMD4KeWUbampBGw2MGqabMPFIbg==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -565,8 +565,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -604,8 +605,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -623,9 +624,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
-
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -640,17 +638,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -672,8 +662,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -715,20 +705,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -779,18 +769,18 @@ packages:
 
 snapshots:
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.3':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -977,7 +967,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tauri-apps/api@2.11.0': {}
+  '@tauri-apps/api@2.11.1': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -990,85 +980,85 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.9.3':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.24.6
 
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
-  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.8
-      ast-v8-to-istanbul: 1.0.0
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.1
+      obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(vite@7.3.1(@types/node@25.6.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.5)(vite@7.3.1(@types/node@25.9.3))
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@25.6.0))':
+  '@vitest/mocker@4.1.9(vite@7.3.1(@types/node@25.9.3))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.6.0)
+      vite: 7.3.1(@types/node@25.9.3)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.9':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.9': {}
 
-  '@vitest/ui@4.1.8(vitest@4.1.8)':
+  '@vitest/ui@4.1.9(vitest@4.1.9)':
     dependencies:
-      '@vitest/utils': 4.1.8
-      fflate: 0.8.2
+      '@vitest/utils': 4.1.9
+      fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(vite@7.3.1(@types/node@25.6.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.5)(vite@7.3.1(@types/node@25.9.3))
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.0:
+  ast-v8-to-istanbul@1.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -1076,7 +1066,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   chai@6.2.2: {}
 
@@ -1084,7 +1074,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1123,15 +1113,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   flatted@3.4.2: {}
 
@@ -1140,9 +1126,9 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  happy-dom@20.10.3:
+  happy-dom@20.10.5:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -1186,19 +1172,19 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.4
 
   mrmime@2.0.1: {}
 
   nanoid@3.3.12: {}
 
-  obug@2.1.1: {}
+  obug@2.1.3: {}
 
   path-parse@1.0.7: {}
 
@@ -1255,7 +1241,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
 
-  semver@7.8.1: {}
+  semver@7.8.4: {}
 
   siginfo@2.0.0: {}
 
@@ -1269,8 +1255,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@4.0.0: {}
-
   std-env@4.1.0: {}
 
   supports-color@7.2.0:
@@ -1281,17 +1265,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -1306,9 +1280,9 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.24.6: {}
 
-  vite@7.3.1(@types/node@25.6.0):
+  vite@7.3.1(@types/node@25.9.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1317,36 +1291,36 @@ snapshots:
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       fsevents: 2.3.3
 
-  vitest@4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(vite@7.3.1(@types/node@25.6.0)):
+  vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.5)(vite@7.3.1(@types/node@25.9.3)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@25.6.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.0.0
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.1(@types/node@25.9.3))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.0.0
+      picomatch: 4.0.4
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.6.0)
+      vite: 7.3.1(@types/node@25.9.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      '@vitest/ui': 4.1.8(vitest@4.1.8)
-      happy-dom: 20.10.3
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/ui': 4.1.9(vitest@4.1.9)
+      happy-dom: 20.10.5
     transitivePeerDependencies:
       - msw
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -72,13 +72,15 @@ pub struct PurchaseOptions {
     pub obfuscated_profile_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app_account_token: Option<String>,
-    /// Purchase token of the existing subscription to replace (Android only).
-    /// When set, the purchase becomes a subscription upgrade/downgrade.
+    /// Product ID of the existing subscription to replace (Android only).
+    /// When set, the purchase becomes a subscription upgrade/downgrade via the
+    /// Billing Library 9.0+ `SubscriptionProductReplacementParams` API.
+    /// Use the previous purchase's `product_id`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_purchase_token: Option<String>,
+    pub old_product_id: Option<String>,
     /// Replacement mode for subscription upgrades/downgrades (Android only).
-    /// Maps to Google Play `BillingFlowParams.SubscriptionUpdateParams.ReplacementMode`.
-    /// Defaults to `WITH_TIME_PRORATION` (1) if not specified.
+    /// Maps to Google Play `BillingFlowParams.ProductDetailsParams.SubscriptionProductReplacementParams.ReplacementMode`.
+    /// Used when `old_product_id` is set. Defaults to `WITH_TIME_PRORATION` (1) if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_replacement_mode: Option<i32>,
     /// Microsoft Store (Windows only): Entra ID access token, passed
@@ -462,13 +464,13 @@ mod tests {
             .expect("Expected PurchaseOptions to be present");
         assert_eq!(opts.offer_token, Some("token".to_string()));
         assert_eq!(opts.obfuscated_account_id, Some("acc123".to_string()));
-        assert_eq!(opts.old_purchase_token, None);
+        assert_eq!(opts.old_product_id, None);
         assert_eq!(opts.subscription_replacement_mode, None);
     }
 
     #[test]
     fn test_purchase_options_with_subscription_update() {
-        let json = r#"{"productId":"prod1","offerToken":"token","oldPurchaseToken":"old_token_123","subscriptionReplacementMode":2}"#;
+        let json = r#"{"productId":"prod1","offerToken":"token","oldProductId":"basic_monthly","subscriptionReplacementMode":2}"#;
         let request: PurchaseRequest =
             serde_json::from_str(json).expect("Failed to deserialize PurchaseRequest");
 
@@ -477,7 +479,7 @@ mod tests {
             .options
             .expect("Expected PurchaseOptions to be present");
         assert_eq!(opts.offer_token, Some("token".to_string()));
-        assert_eq!(opts.old_purchase_token, Some("old_token_123".to_string()));
+        assert_eq!(opts.old_product_id, Some("basic_monthly".to_string()));
         assert_eq!(opts.subscription_replacement_mode, Some(2));
     }
 


### PR DESCRIPTION
## Summary
- Migrate Android subscription upgrades/downgrades from the deprecated `BillingFlowParams.SubscriptionUpdateParams` to `SubscriptionProductReplacementParams` (Billing Library 9.0+), fixing #128 — `WITH_TIME_PRORATION` and `DEFERRED` modes no longer return `DEVELOPER_ERROR`.
- **Breaking**: rename `PurchaseOptions.oldPurchaseToken` → `oldProductId` across TS, Rust, and Kotlin (new API takes a product ID, not a purchase token).
- **Breaking**: realign `SubscriptionReplacementMode` enum int values to the new API (`CHARGE_FULL_PRICE: 5 → 4`, `DEFERRED: 6 → 5`); add `KEEP_EXISTING = 6`. Callers using the named constants are unaffected.
- `KEEP_EXISTING` skips the offer-token (Play rejects the flow otherwise).
- README platform-support corrected to Billing Library v9.0.0.

refs #128 
