### PR TITLE
Fix isAutoRenewing on Apple platforms using renewalInfo.willAutoRenew

### DIFF
--- a/ios/Sources/IapPlugin.swift
+++ b/ios/Sources/IapPlugin.swift
@@ -319,7 +319,15 @@ class IapPlugin: Plugin {
                             if let statuses = try? await product.subscription?.status {
                                 for status in statuses {
                                     if status.state == .subscribed {
-                                        statusResult["isAutoRenewing"] = true
+                                        // `.subscribed` only means the subscription is still active;
+                                        // it does NOT imply auto-renew is on. A subscription that the
+                                        // user cancelled (but hasn't expired yet) is also `.subscribed`.
+                                        // The actual renewal intent lives in renewalInfo.willAutoRenew.
+                                        if case .verified(let renewalInfo) = status.renewalInfo {
+                                            statusResult["isAutoRenewing"] = renewalInfo.willAutoRenew
+                                        } else {
+                                            statusResult["isAutoRenewing"] = true
+                                        }
                                     } else if status.state == .expired {
                                         statusResult["isAutoRenewing"] = false
                                         statusResult["purchaseState"] = PurchaseStateValue.canceled.rawValue
@@ -380,7 +388,13 @@ class IapPlugin: Plugin {
             if let statuses = try? await product.subscription?.status {
                 for status in statuses {
                     if status.state == .subscribed {
-                        isAutoRenewing = true
+                        // `.subscribed` means the subscription is currently active, but a cancelled
+                        // (yet unexpired) subscription also has this state. Use willAutoRenew.
+                        if case .verified(let renewalInfo) = status.renewalInfo {
+                            isAutoRenewing = renewalInfo.willAutoRenew
+                        } else {
+                            isAutoRenewing = true
+                        }
                         break
                     }
                 }

--- a/macos/Sources/IapPlugin.swift
+++ b/macos/Sources/IapPlugin.swift
@@ -248,7 +248,15 @@ class IapPlugin {
                             if let statuses = try? await product.subscription?.status {
                                 for status in statuses {
                                     if status.state == .subscribed {
-                                        statusResult["isAutoRenewing"] = true
+                                        // `.subscribed` only means the subscription is still active;
+                                        // it does NOT imply auto-renew is on. A subscription that the
+                                        // user cancelled (but hasn't expired yet) is also `.subscribed`.
+                                        // The actual renewal intent lives in renewalInfo.willAutoRenew.
+                                        if case .verified(let renewalInfo) = status.renewalInfo {
+                                            statusResult["isAutoRenewing"] = renewalInfo.willAutoRenew
+                                        } else {
+                                            statusResult["isAutoRenewing"] = true
+                                        }
                                     } else if status.state == .expired {
                                         statusResult["isAutoRenewing"] = false
                                         statusResult["purchaseState"] =
@@ -348,7 +356,13 @@ class IapPlugin {
             if let statuses = try? await product.subscription?.status {
                 for status in statuses {
                     if status.state == .subscribed {
-                        isAutoRenewing = true
+                        // `.subscribed` means the subscription is currently active, but a cancelled
+                        // (yet unexpired) subscription also has this state. Use willAutoRenew.
+                        if case .verified(let renewalInfo) = status.renewalInfo {
+                            isAutoRenewing = renewalInfo.willAutoRenew
+                        } else {
+                            isAutoRenewing = true
+                        }
                         break
                     }
                 }


### PR DESCRIPTION
## Summary
- Fix incorrect `isAutoRenewing` on iOS and macOS when a subscription is active but auto-renew has been turned off.
- StoreKit 2's `.subscribed` state only means the subscription is still valid; cancelled-but-not-yet-expired subscriptions also use this state.
- Read `renewalInfo.willAutoRenew` in `getProductStatus` and `createPurchaseObject`, with a fallback to `true` when renewal info is unverified.

## Test plan
- [ ] On iOS/macOS, verify an active auto-renewing subscription reports `isAutoRenewing: true`
- [ ] Cancel a subscription (before expiry) and confirm `isAutoRenewing: false` while still subscribed
- [ ] Confirm expired subscriptions still report `isAutoRenewing: false`


Made with [Cursor](https://cursor.com)