### PR TITLE
fix(macos): forward appAccountToken, and stop losing purchases that fail server verification

### DIFF
--- a/macos/Sources/IapPlugin.swift
+++ b/macos/Sources/IapPlugin.swift
@@ -14,7 +14,23 @@ enum PurchaseStateValue: Int {
 class IapPlugin {
     private var updateListenerTask: Task<Void, Error>?
 
-    init() {
+    /// When false, the plugin never calls `Transaction.finish()` itself — the
+    /// host app must call `acknowledgePurchase` (or `consumePurchase`) once its
+    /// server has validated the receipt, the same contract Google Play imposes
+    /// on Android.
+    ///
+    /// Finishing eagerly is convenient but loses money on failure: a finished
+    /// transaction disappears from `Transaction.updates`, so a purchase whose
+    /// server-side verification failed leaves the customer charged with no
+    /// entitlement and no retry path except Restore.
+    private let finishTransactionsAutomatically: Bool
+
+    /// Exposes the setting to the tests without widening it for callers.
+    var finishesTransactionsAutomaticallyForTesting: Bool { finishTransactionsAutomatically }
+
+    init(finishTransactionsAutomatically: Bool = true) {
+        self.finishTransactionsAutomatically = finishTransactionsAutomatically
+
         // Start listening for transaction updates
         updateListenerTask = Task {
             for await update in Transaction.updates {
@@ -109,10 +125,36 @@ class IapPlugin {
         return try serializeToJSON(["products": productsArray])
     }
 
-    public func purchase(productId: RustString, productType: RustString, offerToken: RustString?)
+    public func purchase(
+        productId: RustString, productType: RustString, offerToken: RustString?,
+        appAccountToken: RustString?
+    )
         async throws(FFIResult) -> String
     {
         let id = productId.as_str().toString()
+
+        // Prepare purchase options.
+        //
+        // Validated BEFORE the product fetch so a malformed token fails
+        // immediately, without a StoreKit round trip, rather than after.
+        var purchaseOptions: Set<Product.PurchaseOption> = []
+
+        // Add appAccountToken if provided (must be a valid UUID). StoreKit
+        // copies it into the signed transaction as `appAccountToken`, which is
+        // what lets a server bind a receipt to the account that bought it —
+        // without it a stolen receipt can be redeemed by whoever presents it
+        // first. Rejecting a non-UUID here rather than dropping it silently
+        // matches iOS: a token that never reaches Apple is a token the server
+        // will never see, and a check that quietly stops running is worse than
+        // one that fails loudly.
+        if let appAccountToken = appAccountToken {
+            let token = appAccountToken.as_str().toString()
+            guard let uuid = UUID(uuidString: token) else {
+                throw FFIResult.Err(
+                    RustString("Invalid appAccountToken: must be a valid UUID string"))
+            }
+            purchaseOptions.insert(.appAccountToken(uuid))
+        }
 
         let products: [Product]
         do {
@@ -126,10 +168,13 @@ class IapPlugin {
             throw FFIResult.Err(RustString("Product not found"))
         }
 
-        // Initiate purchase
+        // Initiate purchase with options
         let result: Product.PurchaseResult
         do {
-            result = try await product.purchase()
+            result =
+                purchaseOptions.isEmpty
+                ? try await product.purchase()
+                : try await product.purchase(options: purchaseOptions)
         } catch {
             throw FFIResult.Err(RustString("Purchase failed: \(error.localizedDescription)"))
         }
@@ -138,8 +183,11 @@ class IapPlugin {
         case .success(let verification):
             switch verification {
             case .verified(let transaction):
-                // Finish the transaction
-                await transaction.finish()
+                // Only finish here when the host app has not taken over
+                // responsibility; see `finishTransactionsAutomatically`.
+                if finishTransactionsAutomatically {
+                    await transaction.finish()
+                }
 
                 let purchase = try await createPurchaseObject(from: verification, product: product)
                 return try serializeToJSON(purchase)
@@ -152,16 +200,58 @@ class IapPlugin {
             throw FFIResult.Err(RustString("Purchase cancelled by user"))
 
         case .pending:
-            throw FFIResult.Err(RustString("Purchase is pending"))
+            // NOT an error. `.pending` is Ask to Buy awaiting a parent's
+            // approval, or an SCA step-up at the bank — the purchase may still
+            // succeed, arriving later through `Transaction.updates`. Reporting
+            // it as a failure shows the buyer a red toast for something that is
+            // working as designed, so return a purchase in the `pending` state
+            // and let the caller decide how to word the wait.
+            return try serializeToJSON(pendingPurchaseObject(productId: id))
 
         @unknown default:
             throw FFIResult.Err(RustString("Unknown purchase result"))
         }
     }
 
+    /// Finishes a transaction the host app has taken responsibility for.
+    ///
+    /// Looked up in `Transaction.unfinished` rather than an in-memory map so it
+    /// still resolves after a relaunch — the case that matters, since an
+    /// unfinished transaction is re-delivered on the next launch and that is
+    /// precisely when the app retries a verification that failed earlier.
+    ///
+    /// An unknown token is treated as success: it means the transaction was
+    /// already finished, which is the state the caller asked for. Erroring
+    /// would make an ordinary retry look like a failure.
+    public func finishTransaction(purchaseToken: RustString) async throws(FFIResult) -> String {
+        let token = purchaseToken.as_str().toString()
+
+        for await result in Transaction.unfinished {
+            guard case .verified(let transaction) = result else { continue }
+            if String(transaction.id) == token {
+                await transaction.finish()
+                break
+            }
+        }
+
+        return try serializeToJSON(["finished": true])
+    }
+
     public func restorePurchases(productType: RustString) async throws(FFIResult) -> String {
         var purchases: [JsonObject] = []
         let requestedType = productType.as_str().toString()
+
+        // Ask the App Store to re-sync before reading entitlements. On a machine
+        // the customer has never launched the app on — or after signing in with
+        // a different Apple Account — `currentEntitlements` is empty until this
+        // runs, and "Restore Purchases did nothing" is a reliable App Review
+        // rejection. Apple requires this be user-initiated, which a Restore
+        // button is.
+        //
+        // A failure here is deliberately not fatal: `sync()` presents an App
+        // Store sign-in sheet, and a customer who dismisses it should still get
+        // whatever entitlements are already cached locally rather than an error.
+        try? await AppStore.sync()
 
         // Get all current entitlements
         for await result in Transaction.currentEntitlements {
@@ -299,13 +389,40 @@ class IapPlugin {
                 }
             }
 
-            // Always finish transactions
-            await transaction.finish()
+            // Finish only when the host app has not taken over. Leaving it
+            // unfinished is what makes the retry possible: StoreKit re-delivers
+            // it here on the next launch until someone acknowledges it.
+            if finishTransactionsAutomatically {
+                await transaction.finish()
+            }
 
         case .unverified(_, _):
             // Handle unverified transaction
             break
         }
+    }
+
+    /// A `Purchase` for a transaction that does not exist yet.
+    ///
+    /// `.pending` has no `Transaction` to describe — StoreKit hands one over
+    /// later, through `Transaction.updates`, if the purchase is approved. The
+    /// shape has to stay in sync with the `Purchase` struct in src/models.rs;
+    /// the ids are empty because there is genuinely nothing to identify yet.
+    // Not `private` so the tests can assert the shape without a StoreKit daemon.
+    func pendingPurchaseObject(productId: String) -> JsonObject {
+        return [
+            "orderId": "",
+            "originalId": "",
+            "packageName": Bundle.main.bundleIdentifier ?? "",
+            "productId": productId,
+            "purchaseTime": 0,
+            "purchaseToken": "",
+            "purchaseState": PurchaseStateValue.pending.rawValue,
+            "isAutoRenewing": false,
+            "isAcknowledged": false,
+            "originalJson": "",
+            "signature": "",
+        ]
     }
 
     private func serializeToJSON(_ object: JsonObject) throws(FFIResult) -> String {
@@ -392,6 +509,6 @@ class IapPlugin {
 }
 
 // Initialize the plugin
-func initPlugin() -> IapPlugin {
-    return IapPlugin()
+func initPlugin(finishTransactionsAutomatically: Bool = true) -> IapPlugin {
+    return IapPlugin(finishTransactionsAutomatically: finishTransactionsAutomatically)
 }

--- a/macos/Tests/PluginTests/PluginTests.swift
+++ b/macos/Tests/PluginTests/PluginTests.swift
@@ -42,6 +42,126 @@ final class PluginTests: XCTestCase {
         XCTAssertNil(PurchaseStateValue(rawValue: 99))
     }
 
+    // MARK: - appAccountToken Tests
+    //
+    // These run without a StoreKit daemon because `purchase()` validates the
+    // token before it fetches the product — which is also why a malformed
+    // token costs no round trip.
+
+    func testPurchaseRejectsNonUUIDAppAccountToken() async {
+        do {
+            _ = try await plugin.purchase(
+                productId: RustString("com.test.premium"),
+                productType: RustString("inapp"),
+                offerToken: nil,
+                appAccountToken: RustString("not-a-uuid")
+            )
+            XCTFail("Expected a non-UUID appAccountToken to be rejected")
+        } catch let error as FFIResult {
+            guard case .Err(let message) = error else {
+                return XCTFail("Expected FFIResult.Err")
+            }
+            XCTAssertTrue(
+                message.toString().contains("Invalid appAccountToken"),
+                "Expected an appAccountToken error, got: \(message.toString())")
+        } catch {
+            XCTFail("Expected FFIResult, got \(error)")
+        }
+    }
+
+    func testPurchaseAcceptsValidUUIDAppAccountToken() async {
+        // A well-formed UUID must get PAST validation. Without a StoreKit
+        // daemon the call still fails at the product fetch, so the assertion is
+        // that it fails for that reason and not for the token.
+        do {
+            _ = try await plugin.purchase(
+                productId: RustString("com.test.premium"),
+                productType: RustString("inapp"),
+                offerToken: nil,
+                appAccountToken: RustString(UUID().uuidString)
+            )
+        } catch let error as FFIResult {
+            guard case .Err(let message) = error else { return }
+            XCTAssertFalse(
+                message.toString().contains("Invalid appAccountToken"),
+                "A valid UUID was rejected as an appAccountToken")
+        } catch {
+            // Any non-FFIResult failure is unrelated to token validation.
+        }
+    }
+
+    /// Lowercase is what Supabase and most UUID libraries emit, uppercase is
+    /// what Apple echoes back in the signed transaction. Both must parse, or
+    /// the binding check breaks for one half of the world.
+    func testPurchaseAcceptsUUIDInEitherCase() async {
+        for token in ["3f7c1f6e-1b2a-4c3d-9e8f-0a1b2c3d4e5f",
+                      "3F7C1F6E-1B2A-4C3D-9E8F-0A1B2C3D4E5F"] {
+            do {
+                _ = try await plugin.purchase(
+                    productId: RustString("com.test.premium"),
+                    productType: RustString("inapp"),
+                    offerToken: nil,
+                    appAccountToken: RustString(token)
+                )
+            } catch let error as FFIResult {
+                guard case .Err(let message) = error else { continue }
+                XCTAssertFalse(
+                    message.toString().contains("Invalid appAccountToken"),
+                    "UUID \(token) was rejected")
+            } catch {
+                continue
+            }
+        }
+    }
+
+    // MARK: - Pending Purchase Tests
+
+    /// `.pending` (Ask to Buy, SCA step-up) must come back as a purchase in the
+    /// pending state rather than an error, and the shape has to deserialize
+    /// into the `Purchase` struct in src/models.rs.
+    func testPendingPurchaseObjectShape() {
+        let pending = plugin.pendingPurchaseObject(productId: "com.test.premium")
+
+        XCTAssertEqual(pending["purchaseState"] as? Int, PurchaseStateValue.pending.rawValue)
+        XCTAssertEqual(pending["productId"] as? String, "com.test.premium")
+        XCTAssertEqual(pending["isAcknowledged"] as? Bool, false)
+        XCTAssertEqual(pending["isAutoRenewing"] as? Bool, false)
+        XCTAssertEqual(pending["purchaseToken"] as? String, "")
+        XCTAssertEqual(pending["purchaseTime"] as? Int, 0)
+
+        // Every non-optional field of `Purchase` must be present or the Rust
+        // side fails to deserialize and the pending case turns back into an
+        // opaque error — the exact thing this is meant to fix.
+        for key in ["orderId", "packageName", "productId", "purchaseTime", "purchaseToken",
+                    "purchaseState", "isAutoRenewing", "isAcknowledged", "originalJson",
+                    "signature", "originalId"] {
+            XCTAssertNotNil(pending[key], "Missing required Purchase field: \(key)")
+        }
+
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(pending))
+    }
+
+    // MARK: - Finish Behavior Tests
+
+    /// Acknowledging a token that is not outstanding is the normal case when
+    /// the plugin finishes automatically, and it is also what a retry looks
+    /// like. It must succeed rather than error.
+    func testFinishTransactionWithUnknownTokenSucceeds() async throws {
+        let json = try await plugin.finishTransaction(purchaseToken: RustString("0"))
+        XCTAssertEqual(parseJSON(json)?["finished"] as? Bool, true)
+    }
+
+    func testDefaultsToFinishingAutomatically() {
+        // The default has to stay `true`: every release before this option
+        // existed finished transactions itself, and an app that upgrades
+        // without opting in must not silently stop acknowledging.
+        XCTAssertTrue(IapPlugin().finishesTransactionsAutomaticallyForTesting)
+        XCTAssertTrue(initPlugin().finishesTransactionsAutomaticallyForTesting)
+        XCTAssertFalse(
+            initPlugin(finishTransactionsAutomatically: false)
+                .finishesTransactionsAutomaticallyForTesting)
+    }
+
 }
 
 // MARK: - StoreKit Integration Tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
     Manager, Runtime,
-    plugin::{Builder, TauriPlugin},
+    plugin::{Builder as PluginBuilder, TauriPlugin},
 };
 
 pub use models::*;
@@ -42,36 +42,106 @@ impl<R: Runtime, T: Manager<R>> crate::IapExt<R> for T {
     }
 }
 
-/// Initializes the plugin.
+/// Plugin-wide settings. Build one with [`Builder`].
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    /// Whether the plugin finishes `StoreKit` transactions on your behalf
+    /// (macOS only — see [`Builder::finish_transactions_automatically`]).
+    pub finish_transactions_automatically: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            // Matches the behavior of every release before this option existed.
+            finish_transactions_automatically: true,
+        }
+    }
+}
+
+/// Builds the plugin with non-default [`Config`].
+///
+/// ```no_run
+/// tauri::Builder::default().plugin(
+///     tauri_plugin_iap::Builder::new()
+///         .finish_transactions_automatically(false)
+///         .build(),
+/// );
+/// ```
+#[derive(Debug, Default)]
+pub struct Builder {
+    config: Config,
+}
+
+impl Builder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Controls whether the plugin calls `Transaction.finish()` for you
+    /// (**macOS only**; the other platforms ignore this).
+    ///
+    /// Defaults to `true`, which finishes a transaction as soon as `StoreKit`
+    /// verifies it — before your server has seen the receipt. If that server
+    /// call then fails, the customer has been charged and the transaction is
+    /// gone from `Transaction.updates`, so the only recovery left is Restore.
+    ///
+    /// Set it to `false` to keep the transaction open until you call
+    /// `acknowledgePurchase` (or `consumePurchase`) yourself, which is the
+    /// same shape Google Play requires on Android. Transactions you never
+    /// acknowledge are re-delivered through `Transaction.updates` on the next
+    /// launch, so a failed verification can be retried instead of lost.
+    ///
+    /// If you set this, you MUST acknowledge; otherwise `StoreKit` re-delivers
+    /// the transaction forever and consumables can never be re-bought.
+    #[must_use]
+    pub const fn finish_transactions_automatically(mut self, finish: bool) -> Self {
+        self.config.finish_transactions_automatically = finish;
+        self
+    }
+
+    #[must_use]
+    pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+        let config = self.config;
+        PluginBuilder::new("iap")
+            .invoke_handler(tauri::generate_handler![
+                commands::initialize,
+                commands::get_products,
+                commands::purchase,
+                commands::restore_purchases,
+                commands::acknowledge_purchase,
+                commands::consume_purchase,
+                commands::get_product_status,
+                #[cfg(desktop)]
+                listeners::register_listener,
+                #[cfg(desktop)]
+                listeners::remove_listener,
+            ])
+            .setup(move |app, api| {
+                #[cfg(desktop)]
+                listeners::init();
+                #[cfg(target_os = "macos")]
+                let iap = macos::init(app, &api, config)?;
+                #[cfg(mobile)]
+                let iap = mobile::init(app, &api)?;
+                #[cfg(target_os = "windows")]
+                let iap = windows::init(app, &api)?;
+                #[cfg(target_os = "linux")]
+                let iap = desktop::init(app, &api)?;
+                // `config` is macOS-only today; keep it live for the others so
+                // adding a second setting doesn't have to touch this closure.
+                #[cfg(not(target_os = "macos"))]
+                let _ = config;
+                app.manage(iap);
+                Ok(())
+            })
+            .build()
+    }
+}
+
+/// Initializes the plugin with default [`Config`].
 #[must_use]
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::new("iap")
-        .invoke_handler(tauri::generate_handler![
-            commands::initialize,
-            commands::get_products,
-            commands::purchase,
-            commands::restore_purchases,
-            commands::acknowledge_purchase,
-            commands::consume_purchase,
-            commands::get_product_status,
-            #[cfg(desktop)]
-            listeners::register_listener,
-            #[cfg(desktop)]
-            listeners::remove_listener,
-        ])
-        .setup(|app, api| {
-            #[cfg(desktop)]
-            listeners::init();
-            #[cfg(target_os = "macos")]
-            let iap = macos::init(app, &api)?;
-            #[cfg(mobile)]
-            let iap = mobile::init(app, &api)?;
-            #[cfg(target_os = "windows")]
-            let iap = windows::init(app, &api)?;
-            #[cfg(target_os = "linux")]
-            let iap = desktop::init(app, &api)?;
-            app.manage(iap);
-            Ok(())
-        })
-        .build()
+    Builder::new().build()
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -50,7 +50,7 @@ mod ffi {
         #[swift_bridge(Sendable)]
         type IapPlugin;
         #[swift_bridge(init, swift_name = "initPlugin")]
-        fn init_plugin() -> IapPlugin;
+        fn init_plugin(finishTransactionsAutomatically: bool) -> IapPlugin;
 
         async fn getProducts(
             &self,
@@ -62,8 +62,10 @@ mod ffi {
             productId: String,
             productType: String,
             offerToken: Option<String>,
+            appAccountToken: Option<String>,
         ) -> Result<String, FFIResult>;
         async fn restorePurchases(&self, productType: String) -> Result<String, FFIResult>;
+        async fn finishTransaction(&self, purchaseToken: String) -> Result<String, FFIResult>;
         async fn getProductStatus(
             &self,
             productId: String,
@@ -111,10 +113,11 @@ fn trigger(event: String, payload: String) -> Result<(), ffi::FFIResult> {
 pub fn init<R: Runtime, C: DeserializeOwned>(
     app: &AppHandle<R>,
     _api: &PluginApi<R, C>,
+    config: crate::Config,
 ) -> crate::Result<Iap<R>> {
     Ok(Iap {
         _app: app.clone(),
-        plugin: ffi::IapPlugin::init_plugin(),
+        plugin: ffi::IapPlugin::init_plugin(config.finish_transactions_automatically),
     })
 }
 
@@ -141,11 +144,18 @@ impl<R: Runtime> Iap<R> {
     pub async fn purchase(&self, payload: PurchaseRequest) -> crate::Result<Purchase> {
         validation::require_bundle()?;
 
+        // Destructured rather than `and_then`-ed twice: `options` is an
+        // `Option<PurchaseOptions>` and the first `and_then` would move it.
+        let (offer_token, app_account_token) = payload
+            .options
+            .map_or((None, None), |opts| (opts.offer_token, opts.app_account_token));
+
         self.plugin
             .purchase(
                 payload.product_id,
                 payload.product_type,
-                payload.options.and_then(|opts| opts.offer_token),
+                offer_token,
+                app_account_token,
             )
             .await
             .parse()
@@ -165,22 +175,33 @@ impl<R: Runtime> Iap<R> {
             .parse()
     }
 
-    /// No-op: macOS finishes transactions inside `purchase()` itself,
-    /// so there is nothing left to acknowledge here.
-    // `async` matches the cross-platform `Iap` contract — `commands.rs` `.await`s
-    // this on every platform, including ones that genuinely yield (Android).
-    #[allow(clippy::unused_async)]
-    pub async fn acknowledge_purchase(&self, _purchase_token: String) -> crate::Result<()> {
+    /// Finishes the transaction, telling `StoreKit` the entitlement has been
+    /// delivered and it can stop re-delivering it.
+    ///
+    /// With the default `finish_transactions_automatically(true)` the plugin has
+    /// already finished it, so this is a no-op — the Swift side treats an
+    /// unknown or already-finished token as success, which keeps the call
+    /// idempotent and safe to retry.
+    pub async fn acknowledge_purchase(&self, purchase_token: String) -> crate::Result<()> {
         validation::require_bundle()?;
-        Ok(())
+
+        self.plugin
+            .finishTransaction(purchase_token)
+            .await
+            .parse::<serde::de::IgnoredAny>()
+            .map(|_| ())
     }
 
-    /// No-op: macOS finishes transactions inside `purchase()` itself,
-    /// and `StoreKit` auto-allows re-purchase of consumables once finished.
-    #[allow(clippy::unused_async)]
-    pub async fn consume_purchase(&self, _purchase_token: String) -> crate::Result<()> {
+    /// Same as [`Self::acknowledge_purchase`]: for a consumable, finishing the
+    /// transaction is exactly what lets `StoreKit` sell it again.
+    pub async fn consume_purchase(&self, purchase_token: String) -> crate::Result<()> {
         validation::require_bundle()?;
-        Ok(())
+
+        self.plugin
+            .finishTransaction(purchase_token)
+            .await
+            .parse::<serde::de::IgnoredAny>()
+            .map(|_| ())
     }
 
     pub async fn get_product_status(

--- a/src/models.rs
+++ b/src/models.rs
@@ -380,6 +380,40 @@ mod tests {
         assert!(json.contains(r#""priceAmountMicros":9990000"#));
     }
 
+    /// The exact JSON the macOS bridge emits for a `.pending` purchase (Ask to
+    /// Buy, SCA step-up) must deserialize into `Purchase`.
+    ///
+    /// The Swift side builds that dictionary by hand, so nothing but this test
+    /// connects the two: if a required field is dropped there, `.pending` stops
+    /// being a pending purchase and turns back into an opaque
+    /// `CannotDeserializeResponse` — the generic error the change was meant to
+    /// remove. Note there is no `jwsRepresentation`: a pending purchase has no
+    /// transaction to sign yet.
+    #[test]
+    fn test_pending_purchase_from_macos_bridge_deserializes() {
+        let json = r#"{
+            "orderId": "",
+            "originalId": "",
+            "packageName": "com.example.app",
+            "productId": "com.example.pro",
+            "purchaseTime": 0,
+            "purchaseToken": "",
+            "purchaseState": 2,
+            "isAutoRenewing": false,
+            "isAcknowledged": false,
+            "originalJson": "",
+            "signature": ""
+        }"#;
+
+        let purchase: Purchase =
+            serde_json::from_str(json).expect("macOS pending purchase must deserialize");
+
+        assert_eq!(purchase.purchase_state, PurchaseStateValue::Pending);
+        assert_eq!(purchase.product_id, "com.example.pro");
+        assert_eq!(purchase.jws_representation, None);
+        assert!(!purchase.is_acknowledged);
+    }
+
     #[test]
     fn test_purchase_serde_roundtrip() {
         let purchase = Purchase {


### PR DESCRIPTION
Four gaps in the macOS StoreKit bridge. Each is something iOS already does, or something Apple's documented flow expects. They're in one PR because they're all the same file and the same review context, but they're independent — happy to split any of them out.

### 1. `appAccountToken` was dropped entirely

The swift-bridge signature is `purchase(productId:productType:offerToken:)`. There's nowhere to put the token, even though `PurchaseOptions` has carried `app_account_token` all along and the iOS plugin forwards it via `.appAccountToken(uuid)`.

This one is a security issue for anyone using the token for its intended purpose. StoreKit copies it into the signed transaction, which is what lets a server bind a receipt to the account that bought it. The natural way to write that server check is:

```js
if (transactionInfo.appAccountToken && transactionInfo.appAccountToken !== user.id) reject()
```

An **absent** claim skips the check rather than failing it — so the check silently does nothing for every macOS receipt, while working correctly on iOS. The failure is invisible from the client side.

Mirrors the iOS implementation, including the UUID validation. One deliberate difference: validation runs **before** the product fetch, so a malformed token fails immediately instead of after a StoreKit round trip. That also makes it testable without a StoreKit daemon (see below).

### 2. Transactions were finished before any server saw them

`purchase()` and the `Transaction.updates` handler both call `transaction.finish()` unconditionally, with no retry queue. A finished transaction is gone from `Transaction.updates` — so if the app's server-side verification fails, the customer has been charged, has no entitlement, and the only recovery left is Restore.

Android can't have this bug, because Play forces `acknowledgePurchase` and refunds anything unacknowledged after 3 days. This adds the same shape to macOS, opt-in:

```rust
tauri_plugin_iap::Builder::new()
    .finish_transactions_automatically(false)
    .build()
```

**Defaults to `true`, so existing apps are completely unaffected.** `init()` is unchanged and now just calls `Builder::new().build()`.

When off, `acknowledge_purchase` / `consume_purchase` stop being no-ops and actually finish the transaction. They resolve the token against `Transaction.unfinished` rather than an in-memory map, so they still work after the relaunch that re-delivers the transaction — which is exactly when an app retries a verification that failed earlier. An unknown token resolves as success, keeping the call idempotent and safe to retry.

### 3. Restore never called `AppStore.sync()`

`restorePurchases` only iterates `Transaction.currentEntitlements`. On a machine the customer has never launched the app on, or after signing in with a different Apple Account, that set is empty — and "Restore Purchases did nothing" is a reliable App Review rejection.

A sync failure is deliberately non-fatal: `sync()` presents a sign-in sheet, and a customer who dismisses it should still get locally cached entitlements rather than an error.

### 4. `.pending` was reported as an error

Ask to Buy awaiting a parent's approval, and an SCA step-up at the bank, are both working as designed and may still complete later via `Transaction.updates`. Throwing means the buyer sees a failure for something that hasn't failed.

Now returns a purchase in the `pending` state, which `PurchaseStateValue` already had. This is the one change with any behavioral surface for existing consumers — a caller that treated "threw" as "didn't succeed" now gets a resolved purchase with `purchaseState: 2`. I think that's the correct reading of the enum, but say the word if you'd rather it stayed an error or went behind the same opt-in.

---

### Testing

- `cargo build`, `cargo clippy --all-targets`, `cargo test` — clean.
- `swift build` / `swift test` in `macos/` — 13 tests pass, with the 3 pre-existing `XCTSkip`s.
- Added 6 tests: UUID validation (reject/accept/either-case), the pending purchase shape (asserting every non-optional field of `Purchase` is present, since a missing one turns the pending case back into an opaque deserialize error), idempotent finish, and that the default stays `true`.

The new tests deliberately avoid `SKTestSession`, which doesn't work under SwiftPM — the existing StoreKit tests all `XCTSkip` with "StoreKit daemon unavailability". **So no test here exercises a real purchase**, and the four fixes still want a sandbox pass on a signed bundle. I'm running that on our side before we ship and will report back anything I find.

### Note

`macos/Sources/generated/` is written by `build.rs` into the source tree but isn't in `.gitignore`, so it shows up as untracked after any macOS build. Left alone here to keep the diff focused, but worth a one-line ignore.