### PR TITLE
Adopt shared CI workflows

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -3,128 +3,20 @@ name: Build Demo
 on:
   pull_request:
   push:
-    branches: ['**']
+    branches: [main]
 
-permissions:
-  contents: read
+concurrency:
+  # Superseded runs cancel per workflow+ref; main is pinned to a unique group
+  # (run_id) so every commit on main gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Build the example app on every desktop OS. Catches platform-specific
-  # regressions.
-  desktop:
-    name: build-demo (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-          version: "1.0"
-
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            examples/iap-demo/src-tauri
-
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Build plugin JS bundle
-        run: |
-          pnpm install
-          pnpm build
-
-      - name: Install demo deps
-        working-directory: examples/iap-demo
-        run: pnpm install
-
-      # `--no-bundle` skips creating .deb/.dmg/.msi installers — we only
-      # care that the app compiles & links on each OS, not that bundlers
-      # work. `--debug` skips release-mode codegen to keep CI fast.
-      - name: Build demo
-        working-directory: examples/iap-demo
-        run: pnpm tauri build --debug --no-bundle
-
-  android:
-    name: build-demo (android)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: "17"
-      - uses: android-actions/setup-android@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: "pnpm"
-      - run: pnpm install && pnpm build
-      - working-directory: examples/iap-demo
-        run: pnpm install
-      # `cargo-ndk` (used internally by `tauri android build`) needs
-      # `NDK_HOME` / `ANDROID_NDK_HOME`. The runner image exposes
-      # `ANDROID_NDK_LATEST_HOME` only as a shell variable (not in the
-      # Actions expression context), so forward it at runtime.
-      - working-directory: examples/iap-demo
-        run: |
-          export NDK_HOME="$ANDROID_NDK_LATEST_HOME"
-          export ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME"
-          pnpm tauri android build --debug --apk --target aarch64
-
-  ios:
-    name: build-demo (ios)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Select Xcode 26.5
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.5"
-
-      - name: Remove MetalToolchain (Tauri + Xcode 26 fix)
-        run: |
-          for i in 1 2 3; do
-            sudo xcodebuild -downloadComponent MetalToolchain && break
-            echo "Attempt $i failed; sleeping 15s and retrying"
-            sleep 15
-          done || echo "MetalToolchain catalog fetch still failing; continuing in case the asset is already on disk"
-          sudo xcodebuild -deleteComponent MetalToolchain
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios-sim
-      - uses: Swatinem/rust-cache@v2
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: "pnpm"
-      - run: pnpm install && pnpm build
-      - working-directory: examples/iap-demo
-        run: pnpm install
-      # iOS Simulator target skips Apple code signing.
-      - working-directory: examples/iap-demo
-        run: pnpm tauri ios build --debug --target aarch64-sim
+  build-demo:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: Choochmeque/reusable-actions/.github/workflows/build-demo.yml@v1
+    with:
+      example-dir: examples/iap-demo
+    secrets: inherit

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,119 +3,20 @@ name: Checks
 on:
   pull_request:
   push:
-    branches: ['**']
-
-permissions:
-  contents: read
+    branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs cancel per workflow+ref; main is pinned to a unique group
+  # (run_id) so every commit on main gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Code formatting.
-  fmt:
-    name: cargo-fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo fmt --all -- --check
-
-  prettier:
-    name: prettier
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: "pnpm"
-      - run: pnpm install
-      - run: pnpm run format:check
-
-  # Static analyzer.
-  clippy:
-    name: cargo-clippy (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf llvm-dev clang cmake grcov
-          version: "1.0"  # bump this to invalidate the cache when needed
-
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used
-
-  # Static analyzer for mobile targets.
-  clippy-mobile:
-    name: cargo-clippy (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - target: aarch64-linux-android
-            os: ubuntu-latest
-          - target: aarch64-apple-ios
-            os: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - run: cargo clippy --lib --target ${{ matrix.target }} -- -D warnings -D clippy::unwrap_used
-
-  # Check links in the documentation.
-  deadlinks:
-    name: cargo-deadlinks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf llvm-dev clang cmake grcov
-          version: "1.0"  # bump this to invalidate the cache when needed
-
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-deadlinks
-      - run: cargo doc --no-deps -p tauri-plugin-iap
-      - run: cargo deadlinks --no-build
-
-  # Check links in markdown files.
-  mlc:
-    name: mlc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: becheran/mlc@v1
-
-  # cargo-deny.
-  deny:
-    name: cargo-deny
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
-
-  # cargo-semver.
-  semver:
-    name: cargo-semver
-    runs-on: ubuntu-latest
-    steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf llvm-dev clang cmake grcov
-          version: "1.0"  # bump this to invalidate the cache when needed
-
-      - uses: actions/checkout@v7
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
-
-  
+  checks:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: Choochmeque/reusable-actions/.github/workflows/checks.yml@v1
+    with:
+      clippy-matrix: '[{"name": "default", "flags": ""}]'
+    secrets: inherit

--- a/.mlc.toml
+++ b/.mlc.toml
@@ -1,6 +1,0 @@
-# Ignore all files ignored by git
-gitignore = true
-# List of links which will be ignored
-ignore-links=["https://www.npmjs.com/package/*","https://crates.io/crates/*"]
-# Wait time in milliseconds between http request to the same host
-throttle= 100


### PR DESCRIPTION
Checks and Build Demo become thin shims calling the shared reusable workflows (v1.3), replacing the repo-local copies:

- Same job set on the reusable side: fmt, prettier, clippy (3 desktop OSes), mobile clippy, cargo-deny, cargo-semver; demo builds on desktop/android/ios — now with path-filter gating, so PRs only run the areas they touch.
- Push-triggered CI is scoped to main (PRs cover topic branches; tags no longer trigger checks), and main runs get a unique concurrency group so they cannot be cancelled by a following push.
- The deadlinks/mlc/spellcheck jobs are dropped.