### PR TITLE
Resolve security advisories in transitive dependencies

### DIFF
--- a/examples/iap-demo/package.json
+++ b/examples/iap-demo/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",
-    "tauri-plugin-iap-api": "file:../../"
+    "tauri-plugin-iap-api": "file:../.."
   },
   "devDependencies": {
     "@choochmeque/tauri-macos-xcode": "^0.2.30",

--- a/examples/iap-demo/pnpm-lock.yaml
+++ b/examples/iap-demo/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1
       tauri-plugin-iap-api:
-        specifier: file:../../
+        specifier: file:../..
         version: '@choochmeque/tauri-plugin-iap-api@file:../..'
     devDependencies:
       '@choochmeque/tauri-macos-xcode':
@@ -404,10 +404,9 @@ packages:
     resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
@@ -1057,7 +1056,7 @@ snapshots:
   '@typescript-eslint/types@8.57.0':
     optional: true
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   acorn@8.18.0: {}
 
@@ -1365,7 +1364,7 @@ snapshots:
 
   plist@5.0.0:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       xmlbuilder: 15.1.1
 
   postcss@8.5.26:


### PR DESCRIPTION
Resolves open Dependabot alerts on transitive dependencies.

- @xmldom/xmldom — medium — GHSA-6gmq-8vp8-gcm6
- glib — medium — GHSA-wrw7-89jp-8q8g

How: @xmldom/xmldom: pnpm update (examples/iap-demo)

A package that is hoisted as an explicit devDependency is one whose vulnerable version is pinned by a peer range and would not move otherwise.